### PR TITLE
Add Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+    - checkout
+
+    - run: |
+        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+        chmod +x ./architect
+        ./architect version
+    - run: ./architect build
+    - deploy:
+        command: |
+          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            ./architect deploy
+          fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/giantswarm/e2esetup.svg?style=svg)](https://circleci.com/gh/giantswarm/e2esetup)
+
 # e2esetup
 
 Package e2esetup implments setup logic for e2e tests again Giant Swarm managed infrastructure.


### PR DESCRIPTION
This is a new e2e library for setup logic needed by multiple operators. First usage will be for aws-operator and cluster-operator. As the cluster-operator tests need an AWS tenant cluster.