### PR TITLE
Return exit code

### DIFF
--- a/chart/setup.go
+++ b/chart/setup.go
@@ -9,16 +9,16 @@ import (
 	"github.com/giantswarm/e2esetup/chart/env"
 )
 
-func Setup(ctx context.Context, m *testing.M, config Config) error {
+func Setup(ctx context.Context, m *testing.M, config Config) (int, error) {
 	var v int
 	var err error
 	var errors []error
 
 	if config.HelmClient == nil {
-		return microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
+		return v, microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
 	}
 	if config.Host == nil {
-		return microerror.Maskf(invalidConfigError, "%T.Host must not be empty", config)
+		return v, microerror.Maskf(invalidConfigError, "%T.Host must not be empty", config)
 	}
 
 	err = config.Host.CreateNamespace("giantswarm")
@@ -51,8 +51,8 @@ func Setup(ctx context.Context, m *testing.M, config Config) error {
 	}
 
 	if len(errors) > 0 {
-		return microerror.Mask(errors[0])
+		return v, microerror.Mask(errors[0])
 	}
 
-	return nil
+	return v, nil
 }


### PR DESCRIPTION
Fixes a bug with the test wrapping logic. We need to return both the result of `m.Run` and any errors. This is so in the tests we can call `os.Exit` and signal to Circle that the job should fail.