### PR TITLE
releaseindex: add

### DIFF
--- a/pkg/releaseindex/error.go
+++ b/pkg/releaseindex/error.go
@@ -1,0 +1,21 @@
+package releaseindex
+
+import "github.com/giantswarm/microerror"
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/pkg/releaseindex/release_index.go
+++ b/pkg/releaseindex/release_index.go
@@ -56,7 +56,7 @@ func New(config Config) (*ReleaseIndex, error) {
 // NOTE: Release index is cached for a provider after first call. This makes it
 // cheap to call this method multiple times with the same provider. But changes
 // to the installations repository will not be visible.
-func (r *ReleaseIndex) GetVersion(ctx context.Context, provider Provider, versionType VersionType, component Authority) (string, error) {
+func (r *ReleaseIndex) GetVersion(ctx context.Context, provider Provider, versionType Version, component Authority) (string, error) {
 	index, err := r.getIndex(ctx, provider)
 	if err != nil {
 		return "", microerror.Mask(err)
@@ -138,7 +138,7 @@ func (r *ReleaseIndex) getIndex(ctx context.Context, provider Provider) ([]versi
 	return index, nil
 }
 
-func getVersion(index []versionbundle.IndexRelease, versionType VersionType, component Authority) (string, error) {
+func getVersion(index []versionbundle.IndexRelease, versionType Version, component Authority) (string, error) {
 	if len(index) < 2 {
 		return "", microerror.Maskf(executionFailedError, "expected at least 2 releases in the index but got %d", len(index))
 	}
@@ -146,9 +146,9 @@ func getVersion(index []versionbundle.IndexRelease, versionType VersionType, com
 	var release versionbundle.IndexRelease
 	{
 		switch versionType {
-		case VersionTypeLast:
+		case VersionLast:
 			release = index[0]
-		case VersionTypePrev:
+		case VersionPrev:
 			release = index[1]
 		default:
 			return "", microerror.Maskf(executionFailedError, "unknown version type %#q", versionType.String())

--- a/pkg/releaseindex/release_index.go
+++ b/pkg/releaseindex/release_index.go
@@ -1,0 +1,163 @@
+package releaseindex
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/versionbundle"
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	// GithubToken is a Github token which is authorized to read from the
+	// installations repository.
+	GithubToken string
+	Logger      micrologger.Logger
+}
+
+type ReleaseIndex struct {
+	githubToken string
+	logger      micrologger.Logger
+
+	cache    map[Provider][]versionbundle.IndexRelease
+	cacheMux *sync.RWMutex
+}
+
+func New(config Config) (*ReleaseIndex, error) {
+	if config.GithubToken == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GithubToken must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &ReleaseIndex{
+		githubToken: config.GithubToken,
+		logger:      config.Logger,
+
+		cache:    map[Provider][]versionbundle.IndexRelease{},
+		cacheMux: &sync.RWMutex{},
+	}
+
+	return r, nil
+}
+
+// GetVersion returns a component version for a given type and provider.
+//
+// NOTE: Release index is cached for a provider after first call. This makes it
+// cheap to call this method multiple times with the same provider. But changes
+// to the installations repository will not be visible.
+func (r *ReleaseIndex) GetVersion(ctx context.Context, provider Provider, versionType VersionType, component Component) (string, error) {
+	index, err := r.getIndex(ctx, provider)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	version, err := getVersion(index, versionType, component)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return version, nil
+}
+
+func (r *ReleaseIndex) getFileContent(ctx context.Context, owner, repo, path string) (string, error) {
+	var client *github.Client
+	{
+		t := &oauth2.Token{
+			AccessToken: r.githubToken,
+		}
+
+		sts := oauth2.StaticTokenSource(t)
+		tc := oauth2.NewClient(ctx, sts)
+
+		client = github.NewClient(tc)
+	}
+
+	opt := &github.RepositoryContentGetOptions{}
+	repoContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, path, opt)
+
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	content, err := repoContent.GetContent()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return content, nil
+}
+
+func (r *ReleaseIndex) getIndex(ctx context.Context, provider Provider) ([]versionbundle.IndexRelease, error) {
+	var err error
+
+	{
+		r.cacheMux.RLock()
+		index, ok := r.cache[provider]
+		r.cacheMux.RUnlock()
+
+		if ok {
+			return index, nil
+		}
+	}
+
+	var indexYAML string
+	{
+		owner := "giantswarm"
+		repo := "installations"
+		path := fmt.Sprintf("release/provider/%s.yaml", provider.String())
+
+		indexYAML, err = r.getFileContent(ctx, owner, repo, path)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var index []versionbundle.IndexRelease
+	{
+		err := yaml.Unmarshal([]byte(indexYAML), &index)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		r.cacheMux.Lock()
+		r.cache[provider] = index
+		r.cacheMux.Unlock()
+	}
+
+	return index, nil
+}
+
+func getVersion(index []versionbundle.IndexRelease, versionType VersionType, component Component) (string, error) {
+	if len(index) < 2 {
+		return "", microerror.Maskf(executionFailedError, "expected at least 2 releases in the index but got %d", len(index))
+	}
+
+	var release versionbundle.IndexRelease
+	{
+		switch versionType {
+		case VersionTypeLatest:
+			release = index[0]
+		case VersionTypeCurrent:
+			release = index[1]
+		default:
+			return "", microerror.Maskf(executionFailedError, "unknown version type %#q", versionType.String())
+		}
+	}
+
+	for _, a := range release.Authorities {
+		if a.Name == component.String() {
+			return a.Version, nil
+		}
+	}
+
+	return "", microerror.Maskf(executionFailedError, "version of type %#q for component %#q not found", versionType.String(), component.String())
+}

--- a/pkg/releaseindex/release_index.go
+++ b/pkg/releaseindex/release_index.go
@@ -56,7 +56,7 @@ func New(config Config) (*ReleaseIndex, error) {
 // NOTE: Release index is cached for a provider after first call. This makes it
 // cheap to call this method multiple times with the same provider. But changes
 // to the installations repository will not be visible.
-func (r *ReleaseIndex) GetVersion(ctx context.Context, provider Provider, versionType VersionType, component Component) (string, error) {
+func (r *ReleaseIndex) GetVersion(ctx context.Context, provider Provider, versionType VersionType, component Authority) (string, error) {
 	index, err := r.getIndex(ctx, provider)
 	if err != nil {
 		return "", microerror.Mask(err)
@@ -140,7 +140,7 @@ func (r *ReleaseIndex) getIndex(ctx context.Context, provider Provider) ([]versi
 	return index, nil
 }
 
-func getVersion(index []versionbundle.IndexRelease, versionType VersionType, component Component) (string, error) {
+func getVersion(index []versionbundle.IndexRelease, versionType VersionType, component Authority) (string, error) {
 	if len(index) < 2 {
 		return "", microerror.Maskf(executionFailedError, "expected at least 2 releases in the index but got %d", len(index))
 	}

--- a/pkg/releaseindex/release_index.go
+++ b/pkg/releaseindex/release_index.go
@@ -20,6 +20,10 @@ type Config struct {
 	Logger      micrologger.Logger
 }
 
+// TODO consider this to be extracted as a library.
+//
+//	See https://github.com/giantswarm/giantswarm/issues/4656
+//
 type ReleaseIndex struct {
 	githubToken string
 	logger      micrologger.Logger

--- a/pkg/releaseindex/release_index.go
+++ b/pkg/releaseindex/release_index.go
@@ -146,9 +146,9 @@ func getVersion(index []versionbundle.IndexRelease, versionType VersionType, com
 	var release versionbundle.IndexRelease
 	{
 		switch versionType {
-		case VersionTypeLatest:
+		case VersionTypeLast:
 			release = index[0]
-		case VersionTypeCurrent:
+		case VersionTypePrev:
 			release = index[1]
 		default:
 			return "", microerror.Maskf(executionFailedError, "unknown version type %#q", versionType.String())

--- a/pkg/releaseindex/spec.go
+++ b/pkg/releaseindex/spec.go
@@ -1,19 +1,19 @@
 package releaseindex
 
-type Component string
+type Authority string
 
-func (c Component) String() string {
+func (c Authority) String() string {
 	return string(c)
 }
 
 const (
-	ComponentAWSOperator     Component = "aws-operator"
-	ComponentAzureOperator   Component = "azure-operator"
-	ComponentCertOperator    Component = "cert-operator"
-	ComponentChartOperator   Component = "chart-operator"
-	ComponentClusterOperator Component = "cluster-operator"
-	ComponentFlannelOperator Component = "flannel-operator"
-	ComponentKVMOperator     Component = "kvm-operator"
+	AuthorityAWSOperator     Authority = "aws-operator"
+	AuthorityAzureOperator   Authority = "azure-operator"
+	AuthorityCertOperator    Authority = "cert-operator"
+	AuthorityChartOperator   Authority = "chart-operator"
+	AuthorityClusterOperator Authority = "cluster-operator"
+	AuthorityFlannelOperator Authority = "flannel-operator"
+	AuthorityKVMOperator     Authority = "kvm-operator"
 )
 
 type Provider string

--- a/pkg/releaseindex/spec.go
+++ b/pkg/releaseindex/spec.go
@@ -28,13 +28,13 @@ const (
 	ProviderKVM   Provider = "kvm"
 )
 
-type VersionType string
+type Version string
 
-func (v VersionType) String() string {
+func (v Version) String() string {
 	return string(v)
 }
 
 const (
-	VersionTypeLast VersionType = "last"
-	VersionTypePrev VersionType = "prev"
+	VersionLast Version = "last"
+	VersionPrev Version = "prev"
 )

--- a/pkg/releaseindex/spec.go
+++ b/pkg/releaseindex/spec.go
@@ -1,0 +1,40 @@
+package releaseindex
+
+type Component string
+
+func (c Component) String() string {
+	return string(c)
+}
+
+const (
+	ComponentAWSOperator     Component = "aws-operator"
+	ComponentAzureOperator   Component = "azure-operator"
+	ComponentCertOperator    Component = "cert-operator"
+	ComponentChartOperator   Component = "chart-operator"
+	ComponentClusterOperator Component = "cluster-operator"
+	ComponentFlannelOperator Component = "flannel-operator"
+	ComponentKVMOperator     Component = "kvm-operator"
+)
+
+type Provider string
+
+func (p Provider) String() string {
+	return string(p)
+}
+
+const (
+	ProviderAWS   Provider = "aws"
+	ProviderAzure Provider = "azure"
+	ProviderKVM   Provider = "kvm"
+)
+
+type VersionType string
+
+func (v VersionType) String() string {
+	return string(v)
+}
+
+const (
+	VersionTypeLatest  VersionType = "latest"
+	VersionTypeCurrent VersionType = "current"
+)

--- a/pkg/releaseindex/spec.go
+++ b/pkg/releaseindex/spec.go
@@ -35,6 +35,6 @@ func (v VersionType) String() string {
 }
 
 const (
-	VersionTypeLatest  VersionType = "latest"
-	VersionTypeCurrent VersionType = "current"
+	VersionTypeLast VersionType = "last"
+	VersionTypePrev VersionType = "prev"
 )


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4573

In cluster-operator we need versions of multiple components. This code
here allows to that. Also it will allow to set version for certconfigs
in other operators and even though we use the same certconfig version
everywhere it feels right.