### PR TITLE
Remove panic when getting Circle env var

### DIFF
--- a/chart/env/common.go
+++ b/chart/env/common.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"fmt"
 	"os"
 )
 
@@ -44,16 +43,12 @@ var (
 
 func init() {
 	circleCI = os.Getenv(EnvVarCircleCI)
+	circleSHA = os.Getenv(EnvVarCircleSHA)
 	keepResources = os.Getenv(EnvVarKeepResources)
 
 	kubeconfig = os.Getenv(EnvVarE2EKubeconfig)
 	if kubeconfig == "" {
 		kubeconfig = e2eHarnessDefaultKubeconfig
-	}
-
-	circleSHA = os.Getenv(EnvVarCircleSHA)
-	if circleSHA == "" {
-		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarCircleSHA))
 	}
 }
 


### PR DESCRIPTION
Needed to get test to pass on https://github.com/giantswarm/e2etests/pull/52

This panic was incorrectly copied across when the code was extracted.