### PR TITLE
Set alt name for internal-api in certconfig

### DIFF
--- a/helm/e2esetup-certs-chart/templates/api-cert.yaml
+++ b/helm/e2esetup-certs-chart/templates/api-cert.yaml
@@ -15,6 +15,7 @@ spec:
     commonName: "api.{{ .Values.cluster.id }}.k8s.{{ .Values.commonDomain }}"
     altNames:
     - "{{ .Values.cluster.id }}.k8s.{{ .Values.commonDomain }}"
+    - "internal-api.{{ .Values.cluster.id }}.k8s.{{ .Values.commonDomain }}"
     - "k8s-master-vm"
     - "kubernetes"
     - "kubernetes.default"


### PR DESCRIPTION
See https://github.com/giantswarm/apiextensions/pull/291. This was moved but we didn't delete the old chart :(
