### PR TITLE
Vault k8s auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,4 @@ workflows:
           command: deploy
           filters:
             branches:
-              only: master
+              only: vault-k8s-auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.7.0
+  architect: giantswarm/architect@0.8.4
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.8.4
+  architect: giantswarm/architect@0.7.0
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,4 @@ workflows:
           command: deploy
           filters:
             branches:
-              only: vault-k8s-auth
+              only: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added sidecar container to setup vault's kubernetes auth backend.
+
 ## [2.0.0] - 2020-08-11
 
 ### Changed

--- a/helm/e2esetup-vault-chart/templates/vault.yaml
+++ b/helm/e2esetup-vault-chart/templates/vault.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: init
+  namespace: default
 data:
   init.sh: |
     #!/bin/sh
@@ -54,7 +55,7 @@ spec:
         - name: init
           configMap:
             name: init
-      restartPolicy: OnFailure
+      restartPolicy: Always
       containers:
         - name: vault
           image: vault:0.10.3

--- a/helm/e2esetup-vault-chart/templates/vault.yaml
+++ b/helm/e2esetup-vault-chart/templates/vault.yaml
@@ -1,3 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: init
+data:
+  init.sh: |
+    #!/bin/sh
+
+    while ! wget -qO /dev/null ${VAULT_ADDR}/v1/sys/health 2>/dev/null
+    do
+    echo "Waiting for vault to be ready"
+    sleep 1
+    done
+
+    if vault read auth/kubernetes/config > /dev/null; then
+    echo "Vault Kubernetes Auth was already configured"
+    exit 0
+    fi
+
+    echo "Configuring Vault Kubernetes Auth"
+
+    vault auth enable kubernetes
+    vault write auth/kubernetes/config token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" kubernetes_host="https://kubernetes.default" kubernetes_ca_cert="$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt)"
+    vault write auth/kubernetes/role/cluster-service bound_service_account_names=cluster-service bound_service_account_namespaces=giantswarm policies=cluster-service ttl=4320h
+    vault write auth/kubernetes/role/cert-operator bound_service_account_names="cert-operator-*" bound_service_account_namespaces=giantswarm policies=cert-operator ttl=4320h
+
+    while :
+    do
+      # 1 year
+      sleep 31536000
+    done
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,6 +50,11 @@ spec:
       labels:
         app: vault
     spec:
+      volumes:
+        - name: init
+          configMap:
+            name: init
+      restartPolicy: OnFailure
       containers:
         - name: vault
           image: vault:0.10.3
@@ -31,7 +69,19 @@ spec:
           - -dev
           - -dev-root-token-id={{.Values.vault.token}}
           - -log-level=debug
-
+        - name: config
+          image: vault:0.10.3
+          volumeMounts:
+            - mountPath: /init/
+              name: init
+          env:
+            - name: VAULT_ADDR
+              value: http://127.0.0.1:8200
+            - name: VAULT_TOKEN
+              value: "{{.Values.vault.token}}"
+          command:
+            - sh
+            - /init/init.sh
 ---
 
 apiVersion: v1


### PR DESCRIPTION
This PR adds a sidecar container to the vault chart that sets up the kubernetes auth backend for vault after vault is started.
This is needed on azure-operator e2e tests because we want to install the cluster-service in the test control planes.